### PR TITLE
Add the ability to whitelist based on permissions and support push-anonymous permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Other configuration options which are helpful to know about:
 # The second for a given group from an external Identity provider
 # The third would be only videos with panopto public permissions
 # The fourth would be all authenticated users at your organization
-permission_whitelist:
+principal_allowlist:
     - Group:Panopto:mygroup
     - Group:MyAdProvider:anothergroup
     - Group:Panopto:Public

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python build_standalone.py
 
 This will produce `dist\panopto-connector.exe` which may be copied to and run as a standalone application. Note that `build_standalone.py` will create a windows executable if run from a windows computer, and a linux executable if run from a linux computer.
 
-### Method 3: Install via easy_setup (recommended for hacking/developing)
+### Method 3: Install via easy_setup (recommended for development)
 
 To install the Panopto Index Connector, follow these steps
 
@@ -124,7 +124,7 @@ Next we recommend running the [debug implementation](the-debug-implementation) b
 
 Next, you will choose a target index connector implementation. That will involve either using one of the predefined connector implementations, or developing your own. If choosing an existing implementation, you may need to make some custom code changes to it depending on your exact scenario. Finally, you will define your config file. See below for more details.
 
-When  you are ready to run the connector, you'll do so by running the following commandline: `panopto-index-connector -c <path-to-config-file>`. Once you have tested your connector, we recommend installing it as a service or daemon on the machine it will run on. 
+When you are ready to run the connector, you'll do so by running the following commandline: `panopto-index-connector -c <path-to-config-file>`. Once you have tested your connector, we recommend installing it as a service or daemon on the machine it will run on. 
 
 See below on how to configure your implementation.
 
@@ -152,6 +152,26 @@ panopto_oauth_credentials:
 ```
 
 Running the debug connector once you have configured your user and your oauth credentials is recommended to confirm that you are set up to correctly talk to the Panopto APIs, before continuing to your final implementation.
+
+Other configuration options which are helpful to know about:
+```yml
+# Allows you to only send videos to the target matching one of a given permission set
+# First bullet would only sync videos with view permission of a given Panopto groups
+# The second for a given group from an external Identity provider
+# The third would be only videos with panopto public permissions
+# The fourth would be all authenticated users at your organization
+permission_whitelist:
+    - Group:Panopto:mygroup
+    - Group:MyAdProvider:anothergroup
+    - Group:Panopto:Public
+    - Group:Panopto:All Users
+
+# Default if empty or blank is false
+# If true, tells the implementation to not push permissions
+# Note this is only supported out of the box for coveo implementation
+skip_permissions: true
+```
+
 
 ### The Coveo implementation
 

--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -97,8 +97,16 @@ class ConnectorConfig:
         return timedelta(seconds=self._yaml_config.get('polling_retry_minimum', 300))
 
     @property
+    def principal_whitelist(self):
+        return self._yaml_config.get('principal_whitelist', None)
+
+    @property
     def sleep_seconds(self):
         return self._yaml_config.get('sleep_seconds', 1)
+
+    @property
+    def skip_permissions(self):
+        return self._yaml_config.get('skip_permissions').lower() == 'true'
 
     @property
     def target_address(self):

--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -62,7 +62,7 @@ class ConnectorConfig:
                 continue
             node = yaml_config[key]
             for node_key in node:
-                # whitelist -- only username and client id should be shown
+                # allowlist -- only username and client id should be shown
                 if node_key not in ('username', 'client_id', 'grant_type'):
                     node[node_key] = '********'
 
@@ -97,8 +97,8 @@ class ConnectorConfig:
         return timedelta(seconds=self._yaml_config.get('polling_retry_minimum', 300))
 
     @property
-    def principal_whitelist(self):
-        return self._yaml_config.get('principal_whitelist', None)
+    def principal_allowlist(self):
+        return self._yaml_config.get('principal_allowlist', None)
 
     @property
     def sleep_seconds(self):

--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -106,7 +106,9 @@ class ConnectorConfig:
 
     @property
     def skip_permissions(self):
-        return self._yaml_config.get('skip_permissions').lower() == 'true'
+        # ensures that this is parsed correctly where interpreted as bool or string
+        # since yaml flexible; maybe too flexible in this case :)
+        return str(self._yaml_config.get('skip_permissions')).lower() == 'true'
 
     @property
     def target_address(self):

--- a/src/panoptoindexconnector/implementations/attivio_implementation.py
+++ b/src/panoptoindexconnector/implementations/attivio_implementation.py
@@ -24,10 +24,12 @@ LOG = logging.getLogger(__name__)
 #########################################################################
 
 
-def convert_to_target(panopto_content, field_mapping):
+def convert_to_target(panopto_content, config):
     """
     Implement this method to convert to target format
     """
+
+    field_mapping = config.field_mapping
 
     target_content = {field_mapping['Id']: panopto_content['Id']}
 

--- a/src/panoptoindexconnector/implementations/debug_implementation.py
+++ b/src/panoptoindexconnector/implementations/debug_implementation.py
@@ -26,10 +26,12 @@ LOG = logging.getLogger(__name__)
 # since this is debug, we'll disable using all the args
 # pylint: disable=unused-argument
 
-def convert_to_target(panopto_content, field_mapping):
+def convert_to_target(panopto_content, config):
     """
     Implement this method to convert to target format
     """
+
+    field_mapping = config.field_mapping
 
     LOG.info('Received the following panopto content: %s', json.dumps(panopto_content, indent=2))
 

--- a/src/panoptoindexconnector/implementations/template.yaml
+++ b/src/panoptoindexconnector/implementations/template.yaml
@@ -25,15 +25,15 @@ target_credentials:
 # The name of your implementation
 target_implementation: debug_implementation
 
-# Should we whitelist videos based on source permissions
-# leave this blank if you will not whitelist which videos are pushed
+# Should we allowlist videos based on source permissions
+# leave this blank if you will not allowlist which videos are pushed
 # based on the source Panopto permissions
-principal_whitelist:
+principal_allowlist:
 #   - User:Panopto:myuser
 #   - Group:MyIdentityProvider:friends-and-family
 
 # Set to "true" if we should not push permissions to the target;
-# often used with the principal_whitelist to control permissions by
+# often used with the principal_allowlist to control permissions by
 # what is synced rather than matching the ID Provider on the target
 skip_permissions: false
 

--- a/src/panoptoindexconnector/implementations/template.yaml
+++ b/src/panoptoindexconnector/implementations/template.yaml
@@ -25,6 +25,18 @@ target_credentials:
 # The name of your implementation
 target_implementation: debug_implementation
 
+# Should we whitelist videos based on source permissions
+# leave this blank if you will not whitelist which videos are pushed
+# based on the source Panopto permissions
+principal_whitelist:
+#   - User:Panopto:myuser
+#   - Group:MyIdentityProvider:friends-and-family
+
+# Set to "true" if we should not push permissions to the target;
+# often used with the principal_whitelist to control permissions by
+# what is synced rather than matching the ID Provider on the target
+skip_permissions: false
+
 # Define the mapping from Panopto fields to the target field names
 field_mapping:
     # Top level data

--- a/src/panoptoindexconnector/implementations/template_implementation.py
+++ b/src/panoptoindexconnector/implementations/template_implementation.py
@@ -24,10 +24,13 @@ LOG = logging.getLogger(__name__)
 #########################################################################
 
 
-def convert_to_target(panopto_content, field_mapping):
+def convert_to_target(panopto_content, config):
     """
-    Implement this method to convert from panopto content format to target format
+    Implement this method to convert to target format
     """
+    # You'll probably only use the field mapping, get it as such
+    # Other relevant values: config.skip_permissions
+    # field_mapping = config.field_mapping
 
     raise NotImplementedError("This is only a template")
 

--- a/src/panoptoindexconnector/target_handler.py
+++ b/src/panoptoindexconnector/target_handler.py
@@ -53,7 +53,7 @@ class TargetHandler:
         Implement this method to convert to target format
         """
         return self._implementation_module.convert_to_target(
-            panopto_video_content, self._config.field_mapping)
+            panopto_video_content, self._config)
 
     def initialize(self):
         """

--- a/test/test_conversions.py
+++ b/test/test_conversions.py
@@ -22,7 +22,7 @@ def test_attivio_conversion():
     from panoptoindexconnector.implementations import attivio_implementation as implementation
     from panoptoindexconnector.connector_config import ConnectorConfig
     attivio_path = os.path.join(DIR, '..', 'src', 'panoptoindexconnector', 'implementations', 'attivio.yaml')
-    field_mapping = ConnectorConfig(attivio_path).field_mapping
+    config = ConnectorConfig(attivio_path)
 
     # Dummy content and useful example
     panopto_content = {
@@ -43,6 +43,6 @@ def test_attivio_conversion():
     }
 
     # Test conversion and assert attivio formatting
-    attivio_content = implementation.convert_to_target(panopto_content, field_mapping)
+    attivio_content = implementation.convert_to_target(panopto_content, config)
 
-    assert attivio_content[field_mapping['Id']] == panopto_content['Id']
+    assert attivio_content[config.field_mapping['Id']] == panopto_content['Id']


### PR DESCRIPTION
This change supports filtering permissions in the connector before pushing to a target source via the permission_whitelist node. It also supports a config flag (which must be implemented by the implementation) for supporting pushing all videos as public to the target. The adds the implementation for Coveo, though other implementations would need to implement this on their own.

The cleanest design was to update the convert_to_target method to take a ConnectorConfig rather than it's element FieldMapping. This is in line with the other two functions needed for each implementation to be defined and should overall simplify the paradigm too.

The readme was updated with helpful examples, including how to use the whitelist to push all videos which are "All User" or "Public", as well as videos on a given user or group.

![image](https://user-images.githubusercontent.com/4721718/123014574-6393c980-d37b-11eb-908a-dbca3b3c7557.png)

Tested via pushing content as "allowAnonymous" to a new coveo target, as well as verified that existing content pushed correctly to the original princpal secured push source. Used the debug implementation to verify all items. Tested the whitelist with a given user, a given group, All Users, and Public. Verified that the program will terminate with a helpful log if an incorrect whitelist element is given.

Additionally, tox succeeds and the standalone build work as well. Performed all testing using the standalone build artifact. I will cut a release after merge with the new "out of the box" connector.