### PR TITLE
#115900 - TeamsV2: Graph Connector doesn't stop syncing when the MSFT…

### DIFF
--- a/src/panoptoindexconnector/connector.py
+++ b/src/panoptoindexconnector/connector.py
@@ -336,6 +336,7 @@ def sync(config, last_update_time):
         LOG.exception('Received error response %s | %s', ex.response.status_code, ex.response.text)
         exception = ex
     except CustomExceptions.QuotaLimitExceededError as ex:
+        # No need to log here since it will be logged in caller method ("run" method)
         exception = ex
     except Exception as ex:  # pylint: disable=broad-except
         LOG.exception('Received general exception')

--- a/src/panoptoindexconnector/custom_exceptions.py
+++ b/src/panoptoindexconnector/custom_exceptions.py
@@ -1,0 +1,12 @@
+class CustomExceptions:
+    """
+    User-defined exceptions
+    """
+
+    class Error(Exception):
+        """Base class for other exceptions"""
+        pass
+
+    class QuotaLimitExceededError(Error):
+        """Raised when the Tenant quota has exceeded"""
+        pass

--- a/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
+++ b/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
@@ -99,10 +99,9 @@ def push_to_target(target_content, config):
             if innerError.get('code') == "TenantQuotaExceeded":
                 raise CustomExceptions.QuotaLimitExceededError(innerError.get("message"))
 
-        response.raise_for_status()
+        log_error_for_not_pushed_content(content_id, target_content, response.text)
     else:
-        LOG.error(f"Content ({content_id}) has NOT been pushed to target! " +
-                  f"Target Content: {target_content}. Response: {response.text}")
+        log_error_for_not_pushed_content(content_id, target_content, response.text)
 
 
 def delete_from_target(video_id, config):
@@ -623,3 +622,12 @@ def check_connection_operation_status(config, operation_url):
 
         # Wait 3 seconds until next check
         time.sleep(3)
+
+
+def log_error_for_not_pushed_content(content_id, target_content, response_text):
+    """
+    Logs error for not pushed content to target
+    """
+
+    LOG.error(f"Content ({content_id}) has NOT been pushed to target! " +
+              f"Target Content: {target_content}. Response: {response_text}")


### PR DESCRIPTION
… tenant quota has been exceeded

PR contains fix where we need to stop sync if Tenant quota limit has excided. 

We have 2 cases when we need to stop sync and display error:
1. When application is started and we get connection which Tenant quota limit is already exceeded. (Initialize method)
2. While syncing items Tenant quota limit exceeded. 

Tested both cases using **panoptodev4** tenant. 

**Resolved Workitem(s):** 115900