### PR TITLE
#115825-TeamsV2: Graph Connector continues to check non-AAD users it …

### DIFF
--- a/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
+++ b/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
@@ -129,6 +129,10 @@ def initialize(config):
     """
 
     try:
+        # Clear users list before each sync attempt to keep up to date AAD users info
+        users.clear()
+
+        # Ensure connection for sync
         ensure_connection_availability(config)
     except Exception as ex:
         LOG.error(f'Error occurred while initializing microsoft graph connector!. Error: {ex}')

--- a/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
+++ b/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
@@ -21,7 +21,7 @@ APP_TEMP_DIR = str.lower(DIR).replace("panoptoindexconnector\implementations", "
 TOKEN_CACHE = os.path.join(APP_TEMP_DIR, 'token_cache.bin')
 
 # Stored users to prevent unnecessary API calls to get id
-users = []
+users = {}
 
 #########################################################################
 #
@@ -286,8 +286,8 @@ def set_principals_to_user(config, panopto_content, target_content):
 
         principal_user_email = principal.get("Email")
 
-        # Try to get user id from users list
-        user_id = get_user_id_from_users_list(principal_user_email)
+        # Try to get user id from users dictionary
+        user_id = users.get(principal_user_email)
 
         # If user doean't exist in list, try to get from AAD calling API
         if not user_id:
@@ -298,7 +298,7 @@ def set_principals_to_user(config, panopto_content, target_content):
                 user_id = aad_user_info["id"]
 
             # Add user to list to prevent further API calls for the same user
-            users.append({principal_user_email: user_id})
+            users[principal_user_email] = user_id
 
         if user_id:
             acl = {
@@ -307,21 +307,6 @@ def set_principals_to_user(config, panopto_content, target_content):
                 "accessType": "grant"
             }
             target_content["acl"].append(acl)
-
-
-def get_user_id_from_users_list(user_email):
-    """
-    Get user id from users list by user e-mail to prevent unnecessary API call to AAD
-    """
-
-    user_id = None
-
-    for user in users:
-        if user.get(user_email):
-            user_id = user.get(user_email)
-            break
-
-    return user_id
 
 
 def get_aad_user_info(config, principal):


### PR DESCRIPTION
PR contains fix where we need to prevent getting users info (needed user id) from AAD by API calls if we already did that once.

To do that I created a users list and append users which info we pulled from AAD, so we can use user id from the list and avoid calling API in same sync attempt.

Users list will be cleared before each sync attempt to keep users up-to-date.

Tested sync on **panoptodev4** tenant and verified that user's info are pulled once per user.

**Resolved Workitem(s):** 115825