### PR TITLE
#116419-Add throttling delay to 0.25 sec for Microsoft Graph connector

### DIFF
--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -42,6 +42,10 @@ target_implementation: microsoft_graph_implementation
 # what is synced rather than matching the ID Provider on the target
 skip_permissions: false
 
+# Sleep time to avoid limitation between synced items per second.
+# Microsoft Graph Connector has limitation of 4 entries per second.
+sleep_seconds: 0.25
+
 # Define the mapping from Panopto fields to the target field names
 field_mapping:
 


### PR DESCRIPTION
Added configuration property `sleep_seconds: 0.25` for throttling to avoid Microsoft Graph Connector limitation of 4 entries per second while syncing items.

1. Tested by adding logs to be sure that entered value is really used.
2. Tested full workflow to be sure that syncing work as expected without any limitation errors.

tfs-116419