### PR TITLE
Ndeliahmetovic/#116458 graph connector hits api quota exceeded timeout within 30 seconds with sleep seconds  0.25 against zoom test.staging 

### DIFF
--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -43,7 +43,6 @@ target_implementation: microsoft_graph_implementation
 skip_permissions: false
 
 # Sleep time to avoid limitation between synced items per second.
-# Microsoft Graph Connector has limitation of 4 entries per second.
 # Panopto API allows 100 request per minute.
 sleep_seconds: 0.6
 

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -44,6 +44,7 @@ skip_permissions: false
 
 # Sleep time to avoid limitation between synced items per second.
 # Microsoft Graph Connector has limitation of 4 entries per second.
+# Panopto API allows 100 request per minute.
 sleep_seconds: 0.6
 
 # Define the mapping from Panopto fields to the target field names

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -44,7 +44,7 @@ skip_permissions: false
 
 # Sleep time to avoid limitation between synced items per second.
 # Microsoft Graph Connector has limitation of 4 entries per second.
-sleep_seconds: 0.25
+sleep_seconds: 0.6
 
 # Define the mapping from Panopto fields to the target field names
 field_mapping:


### PR DESCRIPTION
PR contains change where we need to increase a number for throttling since Panopto API allows max 100 request per minute.

Value has been changed from 0.25 to 0.6