### PR TITLE
#115825 - TeamsV2: Graph Connector continues to check non-AAD users i…

### DIFF
--- a/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
+++ b/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
@@ -299,12 +299,13 @@ def set_principals_to_user(config, panopto_content, target_content):
     for principal in get_unique_external_user_principals(panopto_content):
 
         principal_user_email = principal.get("Email")
+        user_id = None
 
         # Try to get user id from users dictionary
-        user_id = users.get(principal_user_email)
-
-        # If user doean't exist in list, try to get from AAD calling API
-        if not user_id:
+        if principal_user_email in users:
+            user_id = users.get(principal_user_email)
+        # If user doesn't exist in dictionary, try to get from AAD calling API
+        else:
             # Get user from AAD
             aad_user_info = get_aad_user_info(config, principal)
 


### PR DESCRIPTION
PR contains fix to prevent calling AAD API to get user's info (id) if we already did that once. 

Bug had wrong if statement for users that doesn't exist on AAD. If they doesn't exist we are adding to users dictionary user's email as key and None as value. In next check for the same user when we pull value from dictionary we will get None and after that if user is None we will proceed to get user's info from AAD which is wrong. 

We need to check if user exist in dictionary to use his value id or None. We will call API only if user doesn't exist in dictionary.