### PR TITLE
#117397-Graph connector supporting Azure AD user mapping

### DIFF
--- a/src/panoptoindexconnector/connector.py
+++ b/src/panoptoindexconnector/connector.py
@@ -335,7 +335,7 @@ def sync(config, last_update_time):
     except requests.exceptions.HTTPError as ex:
         LOG.exception('Received error response %s | %s', ex.response.status_code, ex.response.text)
         exception = ex
-    except CustomExceptions.QuotaLimitExceededError as ex:
+    except (CustomExceptions.ConfigurationError, CustomExceptions.QuotaLimitExceededError) as ex:
         # No need to log here since it will be logged in caller method ("run" method)
         exception = ex
     except Exception as ex:  # pylint: disable=broad-except

--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -93,6 +93,10 @@ class ConnectorConfig:
         return self._yaml_config['panopto_username_mapping']
 
     @property
+    def panopto_id_provider_instance_name(self):
+        return self._yaml_config['panopto_id_provider_instance_name']
+
+    @property
     def polling_frequency(self):
         return timedelta(seconds=self._yaml_config.get('polling_seconds', 3600))
 

--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -89,6 +89,10 @@ class ConnectorConfig:
         return self._yaml_config['panopto_site_address'].rstrip('/').rstrip('.')
 
     @property
+    def panopto_username_mapping(self):
+        return self._yaml_config['panopto_username_mapping']
+
+    @property
     def polling_frequency(self):
         return timedelta(seconds=self._yaml_config.get('polling_seconds', 3600))
 

--- a/src/panoptoindexconnector/custom_exceptions.py
+++ b/src/panoptoindexconnector/custom_exceptions.py
@@ -11,6 +11,6 @@ class CustomExceptions:
         """Raised when the Tenant quota has exceeded"""
         pass
 
-    class UsernameMappingError(Error):
-        """Raised when configuration username mapping value is not valid"""
+    class ConfigurationError(Error):
+        """Raised when configuration is not properly set"""
         pass

--- a/src/panoptoindexconnector/custom_exceptions.py
+++ b/src/panoptoindexconnector/custom_exceptions.py
@@ -10,3 +10,7 @@ class CustomExceptions:
     class QuotaLimitExceededError(Error):
         """Raised when the Tenant quota has exceeded"""
         pass
+
+    class UsernameMappingError(Error):
+        """Raised when configuration username mapping value is not valid"""
+        pass

--- a/src/panoptoindexconnector/enums.py
+++ b/src/panoptoindexconnector/enums.py
@@ -1,0 +1,13 @@
+"""
+Enums for connector implementations
+"""
+from enum import Enum
+
+class UsernameMapping(Enum):
+    """
+    SAML Azure AD username mapping attribute used for Panopto username
+    """
+
+    USER_PRINCIPAL_NAME = "userPrincipalName"
+    EMAIL = "mail"
+

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -14,6 +14,10 @@ panopto_oauth_credentials:
     client_secret: 456
     grant_type: password
 
+# The attribute from SAML Azure AD that will be used for Panopto username
+# Valid values are: userPrincipalName or mail (Case sensitive)
+panopto_username_mapping: userPrincipalName
+
 # Your index integration target endpoint
 target_address: https://graph.microsoft.com/v1.0/external/connections
 

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -14,7 +14,11 @@ panopto_oauth_credentials:
     client_secret: 456
     grant_type: password
 
-# The attribute from SAML Azure AD that will be used for Panopto username
+# Your Panopto identity provider instance name that will be used
+# for matching users with target Tenant
+panopto_id_provider_instance_name: ""
+
+# The attribute from SAML Azure AD that will be used for Panopto username.
 # Valid values are: userPrincipalName or mail (Case sensitive)
 panopto_username_mapping: userPrincipalName
 


### PR DESCRIPTION
PR contains change were we need to support Azure AD username mapping.

**Explanation:**
When we want to set grant permission for item(session) that needs to be synced, we need to check if user added to Panopto session exist on Azure in order to get his Azure ID.

The process is following:
1. We will take Panopto username from principal - only username, not provider included
2. Based on configuration file we will try to get Azure user using userPrincipalName or mail mapping (e.g. userPrincipalName=Panopto username OR mail=Panopto username)
3. If user exists we will take his ID and set as a grant permission for syncing item.

Additionally, added Panopto identity provider instance name to configuration file that will be used for matching Panopto users with target Tenant.

**Testing**
Tested on Pantest1 tenant since new connector cannot be registered on Panoptodev4 tenant.

tfs-117397