### PR TITLE
#116588-Eliminate UAC warning when running panopto-connector.exe

### DIFF
--- a/build_standalone.py
+++ b/build_standalone.py
@@ -45,7 +45,6 @@ def _build_standalone_installer(name, entrypoint, icon, one_file=True):
             '--icon', icon,
             paths,
             output_type,
-            '--uac-admin',
             '--version-file', 'version_info',
             '--clean', '-y',
         ] + add_data


### PR DESCRIPTION
**Description**
Removed UAC admin privilege and prompting user to allow to run panopto-connector app since it is not needed.

**Testing**
After removing UAC, tested MS Graph connector to ensure that syncing and logging works as expected.