### PR TITLE
Ndeliahmetovic/#117398 (stretch) ms graph connector user group support

### DIFF
--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -93,6 +93,10 @@ class ConnectorConfig:
         return self._yaml_config['panopto_username_mapping']
 
     @property
+    def panopto_user_group_mapping(self):
+        return self._yaml_config['panopto_user_group_mapping']
+
+    @property
     def panopto_id_provider_instance_name(self):
         return self._yaml_config['panopto_id_provider_instance_name']
 

--- a/src/panoptoindexconnector/enums.py
+++ b/src/panoptoindexconnector/enums.py
@@ -11,3 +11,11 @@ class UsernameMapping(Enum):
     USER_PRINCIPAL_NAME = "userPrincipalName"
     EMAIL = "mail"
 
+class UserGroupMapping(Enum):
+    """
+    SAML Azure AD user group mapping attribute used for Panopto user group
+    """
+
+    GROUP_ID = "id"
+    SAM_ACCOUNT_NAME = "onPremisesSamAccountName"
+

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -22,6 +22,12 @@ panopto_id_provider_instance_name: ""
 # Valid values are: userPrincipalName or mail (Case sensitive)
 panopto_username_mapping: userPrincipalName
 
+# The attribute from SAML Azure AD that will be used for Panopto user group mapping.
+# Valid values are (Case sensitive):
+#   'id'- Azure AD group ObjectId or
+#   'onPremisesSamAccountName'- sAMAccountName
+panopto_user_group_mapping: id
+
 # Your index integration target endpoint
 target_address: https://graph.microsoft.com/v1.0/external/connections
 

--- a/version_info
+++ b/version_info
@@ -6,8 +6,8 @@ VSVersionInfo(
     ffi=FixedFileInfo(
         # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
         # Set not needed items to zero 0.
-        filevers=(11, 13, 0, 0),
-        prodvers=(11, 13, 0, 0),
+        filevers=(11, 12, 0, 0),
+        prodvers=(11, 12, 0, 0),
         # Contains a bitmask that specifies the valid bits 'flags'r
         mask=0x3f,
         # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
                     u'040904b0',
                     [
                         StringStruct(u'FileDescription', u'Connects a Panopto search index to an external engine'),
-                        StringStruct(u'FileVersion', u'11.13.0'),
+                        StringStruct(u'FileVersion', u'11.12.0'),
                         StringStruct(u'InternalName', u'Panopto Index Connector'),
                         StringStruct(u'LegalCopyright', u'© Panopto 2019'),
                         StringStruct(u'OriginalFilename', u'panopto-connector.exe'),
                         StringStruct(u'ProductName', u'Panopto Index Connector'),
-                        StringStruct(u'ProductVersion', u'11.13.0'),
+                        StringStruct(u'ProductVersion', u'11.12.0'),
                     ]
                 )
             ]

--- a/version_info
+++ b/version_info
@@ -6,8 +6,8 @@ VSVersionInfo(
     ffi=FixedFileInfo(
         # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
         # Set not needed items to zero 0.
-        filevers=(11, 12, 0, 0),
-        prodvers=(11, 12, 0, 0),
+        filevers=(11, 13, 0, 0),
+        prodvers=(11, 13, 0, 0),
         # Contains a bitmask that specifies the valid bits 'flags'r
         mask=0x3f,
         # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
                     u'040904b0',
                     [
                         StringStruct(u'FileDescription', u'Connects a Panopto search index to an external engine'),
-                        StringStruct(u'FileVersion', u'11.12.0'),
+                        StringStruct(u'FileVersion', u'11.13.0'),
                         StringStruct(u'InternalName', u'Panopto Index Connector'),
                         StringStruct(u'LegalCopyright', u'© Panopto 2019'),
                         StringStruct(u'OriginalFilename', u'panopto-connector.exe'),
                         StringStruct(u'ProductName', u'Panopto Index Connector'),
-                        StringStruct(u'ProductVersion', u'11.12.0'),
+                        StringStruct(u'ProductVersion', u'11.13.0'),
                     ]
                 )
             ]


### PR DESCRIPTION
PR contains changes to support User Group mappings between Panopto and Azure AD groups.
To accomplish this we had to make changes on Server side where we included new property ExternalContexts for Solr that holds IdentityProviderName and ExternalId (ExternalContext.context) values.

In most cases ExternalContexts will contain only one external context per group but we had to support case with multiple, too.

Tested locally with Solr changes.