### PR TITLE
#116464-Update federated search API throttling more premissive

### DIFF
--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -51,8 +51,8 @@ target_implementation: microsoft_graph_implementation
 skip_permissions: false
 
 # Sleep time to avoid limitation between synced items per second.
-# Panopto API allows 100 request per minute.
-sleep_seconds: 0.6
+# Microsoft Graph Connector has limitation of 4 entries per second.
+sleep_seconds: 0.25
 
 # Define the mapping from Panopto fields to the target field names
 field_mapping:


### PR DESCRIPTION
PR contains change to decrease sleep time from 0.6 to 0.25 sec that will allow us support maximum speed of ingestion to MSFT Graph Connector.

Change is related to `panopto-core` [PR ](https://github.com/Panopto/panopto-core/pull/25433)

