### PR TITLE
#118393-Update MSFT Graph connector version to 12.0

### DIFF
--- a/version_info
+++ b/version_info
@@ -6,8 +6,8 @@ VSVersionInfo(
     ffi=FixedFileInfo(
         # filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)
         # Set not needed items to zero 0.
-        filevers=(11, 12, 0, 0),
-        prodvers=(11, 12, 0, 0),
+        filevers=(12, 0, 0, 0),
+        prodvers=(12, 0, 0, 0),
         # Contains a bitmask that specifies the valid bits 'flags'r
         mask=0x3f,
         # Contains a bitmask that specifies the Boolean attributes of the file.
@@ -31,12 +31,12 @@ VSVersionInfo(
                     u'040904b0',
                     [
                         StringStruct(u'FileDescription', u'Connects a Panopto search index to an external engine'),
-                        StringStruct(u'FileVersion', u'11.12.0'),
+                        StringStruct(u'FileVersion', u'12.0.0'),
                         StringStruct(u'InternalName', u'Panopto Index Connector'),
                         StringStruct(u'LegalCopyright', u'© Panopto 2019'),
                         StringStruct(u'OriginalFilename', u'panopto-connector.exe'),
                         StringStruct(u'ProductName', u'Panopto Index Connector'),
-                        StringStruct(u'ProductVersion', u'11.12.0'),
+                        StringStruct(u'ProductVersion', u'12.0.0'),
                     ]
                 )
             ]


### PR DESCRIPTION
PR contains change for version of Graph connector after implementation for user group permissions and a few more improvements.

tfs-118393