### PR TITLE
Updated documentation link for Graph connector to navigate to support…

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ It assumes that Panopto user names map to Attivio user names, as will be the cas
 ### The Microsoft Graph Connector implementation
 
 The Microsoft Graph Connector implementation, under `microsoft_graph_implementation.py`, works out of the box with Microsoft 365.
-To configure this implementation, please refer [this document](https://docs.google.com/document/d/1CbnS4VnoKponmPx0CaxncpjPRpT7NEJ50XamLHTm4J4/edit?usp=sharing).
+To configure this implementation, please refer [this document](https://support.panopto.com/s/article/How-to-Set-Up-Panopto-Federated-Search-in-Microsoft-365).
 
 ### Developing or customizing an implementation
 


### PR DESCRIPTION
We need to update document link within README.md file for Graph connector instructions to navigate to support article instead of Gdoc.