### PR TITLE
Graph connector permission bugs - #122457 and #121782

### DIFF
--- a/src/panoptoindexconnector/connector_config.py
+++ b/src/panoptoindexconnector/connector_config.py
@@ -101,6 +101,11 @@ class ConnectorConfig:
         return self._yaml_config['panopto_id_provider_instance_name']
 
     @property
+    def panopto_id_provider_is_unified(self):
+        # ensures that configuration value is parsed correctly
+        return str(self._yaml_config.get('panopto_id_provider_is_unified')).lower() == 'true'
+
+    @property
     def polling_frequency(self):
         return timedelta(seconds=self._yaml_config.get('polling_seconds', 3600))
 

--- a/src/panoptoindexconnector/implementations/microsoft_graph.yaml
+++ b/src/panoptoindexconnector/implementations/microsoft_graph.yaml
@@ -18,6 +18,10 @@ panopto_oauth_credentials:
 # for matching users with target Tenant
 panopto_id_provider_instance_name: ""
 
+# Indicates if your Panopto identity provider is unified
+# Valid values are: true or false
+panopto_id_provider_is_unified: false
+
 # The attribute from SAML Azure AD that will be used for Panopto username.
 # Valid values are: userPrincipalName or mail (Case sensitive)
 panopto_username_mapping: userPrincipalName

--- a/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
+++ b/src/panoptoindexconnector/implementations/microsoft_graph_implementation.py
@@ -235,6 +235,8 @@ def set_principals(config, panopto_content, target_content):
             set_principals_to_all(config, target_content)
         # Set user and/or user group grant principals if exist
         elif set_user_principals or set_user_group_principals:
+            target_content["acl"] = []
+
             if set_user_principals:
                 set_principals_to_user(config, panopto_content, target_content)
             if set_user_group_principals:
@@ -274,9 +276,10 @@ def get_unique_external_user_principals(config, panopto_content):
 
     for p in panopto_content['VideoContent']['Principals']:
         if (p not in unique_external_user_principals and
-                p.get('Username') and p.get('Email') and
+                p.get('Username') and
                 p.get('IdentityProvider') and
-                p.get('IdentityProvider').lower() == config.panopto_id_provider_instance_name.lower()):
+                p.get('IdentityProvider').lower() ==
+                ("unified" if config.panopto_id_provider_is_unified else config.panopto_id_provider_instance_name.lower())):
 
             unique_external_user_principals.append(p)
 
@@ -357,8 +360,6 @@ def set_principals_to_user(config, panopto_content, target_content):
     Set session permission to user
     """
 
-    target_content["acl"] = []
-
     for principal in get_unique_external_user_principals(config, panopto_content):
 
         panopto_username = get_panopto_username(principal)
@@ -391,8 +392,6 @@ def set_principals_to_user_group(config, panopto_content, target_content):
     """
     Set session permission to user group
     """
-
-    target_content["acl"] = []
 
     for ec in get_unique_user_group_external_contexts(config, panopto_content):
 


### PR DESCRIPTION
PR contains fixes for following bugs:

**1. #121782 - Graph Connector uses 'unified' instead of IDP Instance Name after IDP consolidation/unification**
To fix this bug we had to update `microsoft_graph.yaml` configuration file by adding new setting `panopto_id_provider_is_unified` that will be used to filter user permissions if users belongs to unified Panopto Identity provider.

Also, I noticed that `unified` user doesn't need to have email, so I removed email condition while checking if any of user permissions exist on session because that information is not used anywhere and not necessary at all.

**2. #122457 - Graph connector - user permissions are overwritten by user group permissions**
While testing the first bug I noticed that user group permission overwrites added user permissions for synced session, so I moved initializing "acl" list before user and/or user groups permissions are proccessed.

tfs-121782
tfs-122457
